### PR TITLE
Escaping should works after reconnect to database

### DIFF
--- a/tests/dibi/Connection.connect.phpt
+++ b/tests/dibi/Connection.connect.phpt
@@ -53,6 +53,17 @@ test(function () use ($config) {
 
 
 test(function () use ($config) {
+	$conn = new Connection($config);
+	Assert::equal('hello', $conn->query('SELECT %s', 'hello')->fetchSingle());
+
+	$conn->disconnect();
+
+	$conn->connect();
+	Assert::equal('hello', $conn->query('SELECT %s', 'hello')->fetchSingle());
+});
+
+
+test(function () use ($config) {
 	Assert::exception(function () use ($config) {
 		new Connection($config + ['onConnect' => '']);
 	}, InvalidArgumentException::class, "Configuration option 'onConnect' must be array.");


### PR DESCRIPTION
- bug fix: yes
- BC break? no

Escaping of string makes on mysqli escape functions should works on reconnected connection.